### PR TITLE
fix: remove Google Sitemap ping functionality

### DIFF
--- a/src/google_deployer.ts
+++ b/src/google_deployer.ts
@@ -112,22 +112,6 @@ export const deployer = async (args: Hexo) => {
     log.error(logPrefix.concat('Submit to google engine error: \x1b[31m', error, '\x1b[39m'))
   }
 
-  try {
-    // Part.2 Google Ping https://www.google.com/ping?sitemap=
-    let sitemap_options = {
-      url: '/ping?sitemap='.concat(url.concat('/', sitemap)),
-      baseURL: 'https://www.google.com'
-    }
-
-    let response = await axios.request(sitemap_options)
-    if (response.status === 200) {
-      log.info(logPrefix.concat("Google Sitemap Notification Received."))
-    }
-  } catch (error: any) {
-    log.error(logPrefix.concat('Submit to google sitmap engine error: \x1b[31m', error.message, '\x1b[39m'))
-  }
-}
-
 const randomRangeNumber = (minNumber: number, maxNumber: number) => {
   let range = maxNumber - minNumber
   let random = Math.random()


### PR DESCRIPTION
如 [#15](https://github.com/abnerwei/hexo-url-submission/issues/15#issuecomment-2495472638) 里面所提到的，google ping sitemap 关停了，现在继续提交只会报 404 错误了，希望把关于提交 sitemap 的代码删除。

相关参考信息：
https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping?hl=zh-cn
https://support.google.com/webmasters/thread/251282922/is-google-ping-sitemap-still-effective?hl=en

fix #15 
