### PR TITLE
docs: add proxy address for Google submission in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ yarn add hexo-url-submission
 ```yaml
 url_submission:
    enable: true
+   proxy: #'http://127.0.0.1:1080' # Proxy address for google submission
    type: 'latest' # latest or all( latest: modified pages; all: posts & pages)
    channels: # included channels are `baidu`, `google`, `bing`, `shenma`
      baidu:


### PR DESCRIPTION
看到 2.0 版本的时候添加了对代理的支持，但文档里面没有写，之前用的时候都不知道有这个。